### PR TITLE
Update alias-finder.plugin.zsh

### DIFF
--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -14,7 +14,7 @@ alias-finder() {
     esac
   done
   cmd=$(sed 's/[].\|$(){}?+*^[]/\\&/g' <<< $cmd) # adds escaping for grep
-  if [[ $(wc -l <<< $cmd) == 1 ]]; then
+  if (( $(wc -l <<< $cmd) == 1 )); then
     while [[ $cmd != "" ]]; do
       if [[ $longer = true ]]; then
         wordStart="'{0,1}"


### PR DESCRIPTION
Never use `[[` for numeric comparisons, for that, we’ll use `((`.